### PR TITLE
Research study mapping v2

### DIFF
--- a/spec/mcode.spec.ts
+++ b/spec/mcode.spec.ts
@@ -2420,3 +2420,21 @@ describe('checkHistologyMorphologyFilterLogic-dcis', () => {
     expect(extractedMCODE.getHistologyMorphologyValue()).toBe('dcis');
   });
 });
+describe('checkECOGFilterLogic', () => {
+  //Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  extractedMCODE.ecogPerformaceStatus = 3;
+  // ECOG Test
+  it('Test ECOG Filter', () => {
+    expect(extractedMCODE.getECOGScore()).toBe(3);
+  });
+});
+describe('checkKarnofskyFilterLogic', () => {
+  //Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  extractedMCODE.karnofskyPerformanceStatus = 90;
+  // Karnofsky Test
+  it('Test Karnofsky Filter', () => {
+    expect(extractedMCODE.getKarnofskyScore()).toBe(90);
+  });
+});

--- a/spec/mcode.spec.ts
+++ b/spec/mcode.spec.ts
@@ -1,5 +1,5 @@
 import * as mcode from "../src/mcode";
-import { Coding } from "../src/mcode";
+import { Coding, PrimaryCancerCondition } from "../src/mcode";
 
 describe("checkMedicationStatementFilterLogic-NoMedications", () => {
   // Initialize
@@ -2335,5 +2335,88 @@ describe('checkAgeFilterLogic', () => {
     const milliseconds1Years = 1000 * 60 * 60 * 24 * 365;
     extractedMCODE.birthDate = birthdate;
     expect(extractedMCODE.getAgeValue()).toBe(Math.floor(millisecondsAge/milliseconds1Years));
+  });
+});
+describe('checkHistologyMorphologyFilterLogic-ibc', () => {
+  // Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  const pcc: PrimaryCancerCondition = {};
+  pcc.clinicalStatus = [] as Coding[];
+  pcc.coding = [] as Coding[];
+  pcc.histologyMorphologyBehavior = [] as Coding[];
+
+  // Invasive Breast Cancer Filter Attributes
+  pcc.coding.push({ system: 'http://snomed.info/sct', code: '783541009', display: 'N/A' } as Coding); // Any Code in 'Cancer-Breast'
+  pcc.histologyMorphologyBehavior.push({
+    system: 'http://snomed.info/sct',
+    code: '446688004',
+    display: 'N/A'
+  } as Coding); // Any code in 'Morphology-Invasive'
+
+  extractedMCODE.primaryCancerCondition.push(pcc);
+
+  it('Test Invasive Breast Cancer Filter', () => {
+    expect(extractedMCODE.getHistologyMorphologyValue()).toBe('ibc');
+  });
+});
+describe('checkHistologyMorphologyFilterLogic-idc', () => {
+  // Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  const pcc: PrimaryCancerCondition = {};
+  pcc.clinicalStatus = [] as Coding[];
+  pcc.coding = [] as Coding[];
+  pcc.histologyMorphologyBehavior = [] as Coding[];
+
+  // Invasive Ductal Carcinoma Filter Attributes
+  pcc.coding.push({ system: 'http://snomed.info/sct', code: '783541009', display: 'N/A' } as Coding); // Any Code in 'Cancer-Breast'
+  pcc.histologyMorphologyBehavior.push({
+    system: 'http://snomed.info/sct',
+    code: '444134008',
+    display: 'N/A'
+  } as Coding); // Any code in 'Morphology-Invas_Duct_Carc'
+
+  extractedMCODE.primaryCancerCondition.push(pcc);
+
+  it('Test Invasive Invasive Ductal Carcinoma Filter', () => {
+    expect(extractedMCODE.getHistologyMorphologyValue()).toBe('idc');
+  });
+});
+describe('checkHistologyMorphologyFilterLogic-ilc', () => {
+  // Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  const pcc: PrimaryCancerCondition = {};
+  pcc.clinicalStatus = [] as Coding[];
+  pcc.coding = [] as Coding[];
+  pcc.histologyMorphologyBehavior = [] as Coding[];
+
+  // Invasive Lobular Carcinoma Filter Attributes
+  pcc.coding.push({ system: 'http://snomed.info/sct', code: '1080261000119100', display: 'N/A' } as Coding); // Any Code in 'Cancer-Invas Lob Carc'
+
+  extractedMCODE.primaryCancerCondition.push(pcc);
+
+  it('Test Invasive Lobular Carcinoma Filter', () => {
+    expect(extractedMCODE.getHistologyMorphologyValue()).toBe('ilc');
+  });
+});
+describe('checkHistologyMorphologyFilterLogic-dcis', () => {
+  // Initialize
+  const extractedMCODE = new mcode.ExtractedMCODE(null);
+  const pcc: PrimaryCancerCondition = {};
+  pcc.clinicalStatus = [] as Coding[];
+  pcc.coding = [] as Coding[];
+  pcc.histologyMorphologyBehavior = [] as Coding[];
+
+  // Ductal Carcinoma In Situ Filter Attributes
+  pcc.coding.push({ system: 'http://snomed.info/sct', code: '783541009', display: 'N/A' } as Coding); // Any Code in 'Cancer-Breast'
+  pcc.histologyMorphologyBehavior.push({
+    system: 'http://snomed.info/sct',
+    code: '18680006',
+    display: 'N/A'
+  } as Coding); // Any code in 'Morphology-Duct_Car_In_Situ'
+
+  extractedMCODE.primaryCancerCondition.push(pcc);
+
+  it('Test Ductal Carcinoma In Situ Filter', () => {
+    expect(extractedMCODE.getHistologyMorphologyValue()).toBe('dcis');
   });
 });

--- a/spec/query.spec.ts
+++ b/spec/query.spec.ts
@@ -247,7 +247,7 @@ describe("APIQuery", () => {
         ],
       }).toString()
     ).toEqual(
-      '{"zip":"01730","distance":25,"phase":"phase-1","status":"approved","biomarkers":[],"stage":null,"cancerType":null,"cancerSubType":null,"ecog":null,"karnofsky":null,"medications":[],"radiationProcedures":[],"surgicalProcedures":[],"metastasis":null,"age":null}'
+      '{"zip":"01730","distance":25,"phase":"phase-1","status":"approved","biomarkers":[],"stage":null,"cancerType":null,"cancerSubType":null,"ecog":null,"karnofsky":null,"medications":[],"procedures":[],"metastasis":null,"age":null}'
     );
   });
 

--- a/src/mcode.ts
+++ b/src/mcode.ts
@@ -522,8 +522,7 @@ export class ExtractedMCODE {
     return null;
   }
 
-  // TODO - This will almost certainly be changed with new details from Trialjectory.
-  // Histology Morphology Value
+  // Histology Morphology Value (cancerSubType)
   getHistologyMorphologyValue(): string {
     if (
       this.primaryCancerCondition.length == 0 &&
@@ -532,22 +531,9 @@ export class ExtractedMCODE {
     ) {
       return null;
     }
-    // Invasive Mammory Carcinoma
-    for (const primaryCancerCondition of this.primaryCancerCondition) {
-      if (
-        (primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Breast')) &&
-          primaryCancerCondition.histologyMorphologyBehavior.some((histMorphBehav) =>
-            this.codeIsInSheet(histMorphBehav, 'Morphology-Invas_Carc_Mix')
-          )) ||
-        (primaryCancerCondition.coding.some(
-          (coding) => this.normalizeCodeSystem(coding.system) == 'SNOMED' && coding.code == '444604002'
-        ) &&
-          this.TNMClinicalStageGroup.some((code) => this.codeIsNotInSheet(code, 'Stage-0'))) ||
-        this.TNMPathologicalStageGroup.some((code) => this.codeIsNotInSheet(code, 'Stage-0'))
-      ) {
-        return 'INVASIVE_MAMMORY_CARCINOMA';
-      }
-    }
+
+    // Each Trialjectory cancerSubType value is represented except: lcis
+
     // Invasive Ductal Carcinoma
     for (const primaryCancerCondition of this.primaryCancerCondition) {
       if (
@@ -557,7 +543,8 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invas_Duct_Carc'))
       ) {
-        return 'INVASIVE_DUCTAL_CARCINOMA';
+        // return 'INVASIVE_DUCTAL_CARCINOMA';
+        return 'idc';
       }
     }
     // Invasive Lobular Carcinoma
@@ -570,7 +557,8 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invas_Lob_Carc'))
       ) {
-        return 'INVASIVE_LOBULAR_CARCINOMA';
+        // return 'INVASIVE_LOBULAR_CARCINOMA';
+        return 'ilc';
       }
     }
     // Ductual Carcinoma in Situ
@@ -581,36 +569,8 @@ export class ExtractedMCODE {
           this.codeIsInSheet(histMorphBehav, 'Morphology-Duct_Car_In_Situ')
         )
       ) {
-        return 'DUCTAL_CARCINOMA_IN_SITU';
-      }
-    }
-    // Non-Inflammatory, Invasive
-    for (const primaryCancerCondition of this.primaryCancerCondition) {
-      if (
-        ((primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Breast')) &&
-          primaryCancerCondition.histologyMorphologyBehavior.some((histMorphBehav) =>
-            this.codeIsInSheet(histMorphBehav, 'Morphology-Invasive')
-          )) ||
-          primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invasive-Breast'))) &&
-        ((primaryCancerCondition.coding.some((code) => this.codeIsNotInSheet(code, 'Cancer-Breast')) &&
-          primaryCancerCondition.histologyMorphologyBehavior.some((code) =>
-            this.codeIsNotInSheet(code, 'Morphology-Inflammatory')
-          )) ||
-          primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Inflammatory')))
-      ) {
-        return 'NON-INFLAMMATORY_INVASIVE';
-      }
-    }
-    // Invasive Carcinoma
-    for (const primaryCancerCondition of this.primaryCancerCondition) {
-      if (
-        (primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Breast')) &&
-          primaryCancerCondition.histologyMorphologyBehavior.some((histMorphBehav) =>
-            this.codeIsInSheet(histMorphBehav, 'Morphology-Invasive-Carcinoma')
-          )) ||
-        primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invasive-Carcinoma'))
-      ) {
-        return 'INVASIVE_CARCINOMA';
+        // return 'DUCTAL_CARCINOMA_IN_SITU';
+        return 'dcis';
       }
     }
     // Invasive Breast Cancer
@@ -622,20 +582,8 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invasive-Breast'))
       ) {
-        return 'INVASIVE_BREAST_CANCER';
-      }
-    }
-    // Inflammatory
-    for (const primaryCancerCondition of this.primaryCancerCondition) {
-      if (
-        (primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Breast')) &&
-          primaryCancerCondition.histologyMorphologyBehavior.some(
-            (histMorphBehav) =>
-              this.normalizeCodeSystem(histMorphBehav.system) == 'SNOMED' && histMorphBehav.code == '32968003'
-          )) ||
-        primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Inflammatory'))
-      ) {
-        return 'INFLAMMATORY';
+        // return 'INVASIVE_BREAST_CANCER';
+        return 'ibc';
       }
     }
     // None of the conditions are satisfied.

--- a/src/mcode.ts
+++ b/src/mcode.ts
@@ -531,9 +531,6 @@ export class ExtractedMCODE {
     ) {
       return null;
     }
-
-    // Each Trialjectory cancerSubType value is represented except: lcis
-
     // Invasive Ductal Carcinoma
     for (const primaryCancerCondition of this.primaryCancerCondition) {
       if (
@@ -543,7 +540,7 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invas_Duct_Carc'))
       ) {
-        // return 'INVASIVE_DUCTAL_CARCINOMA';
+        // idc (Invasice Ductal Carcinoma)
         return 'idc';
       }
     }
@@ -557,7 +554,7 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invas_Lob_Carc'))
       ) {
-        // return 'INVASIVE_LOBULAR_CARCINOMA';
+        // ilc '(Invasive Lobular Carcinoma)
         return 'ilc';
       }
     }
@@ -569,7 +566,7 @@ export class ExtractedMCODE {
           this.codeIsInSheet(histMorphBehav, 'Morphology-Duct_Car_In_Situ')
         )
       ) {
-        // return 'DUCTAL_CARCINOMA_IN_SITU';
+        // dcis (Ductal Carcinoma In Situ)
         return 'dcis';
       }
     }
@@ -582,7 +579,7 @@ export class ExtractedMCODE {
           )) ||
         primaryCancerCondition.coding.some((code) => this.codeIsInSheet(code, 'Cancer-Invasive-Breast'))
       ) {
-        // return 'INVASIVE_BREAST_CANCER';
+        // ibc (Invasive Breast Cancer)
         return 'ibc';
       }
     }
@@ -590,21 +587,8 @@ export class ExtractedMCODE {
     return null;
   }
 
-  // --Procedures--
-  // lumpectomy
-  // mastectomy
-  // alnd
-  // reconstruction
-  // wbrt
-  // radiation
-  // metastasis_resection
-  // ablation
-  // rfa
-  // ebrt
-
   // Radiation Procedures
   getRadiationProcedureValue(): string[] {
-    // Trialjectory does not differentiate between radiation/surgical procedures. How will that translate to the mCODE filters of radiation/surgical procedures?
 
     const radiationValues:string[] = [];
 
@@ -621,13 +605,13 @@ export class ExtractedMCODE {
             (coding.code == '12738006' || coding.code == '119235005')
         )
       ) {
-        radiationValues.push('WBRT');
+        radiationValues.push('wbrt');
       }
     }
 
-    // No logic for this?
-    if (radiationValues.length == 0) {
-      radiationValues.push('RADIATION_THERAPY');
+    if (this.cancerRelatedRadiationProcedure.length > 0) {
+      // If there is any code in the cancerRelatedRadiationProcedure, it counts as radiation.
+      radiationValues.push('radiation');
     }
 
     return radiationValues;
@@ -636,12 +620,7 @@ export class ExtractedMCODE {
   // Surgical Procedures
   getSurgicalProcedureValue(): string[] {
     const surgicalValues:string[] = [];
-
-    if (this.cancerRelatedSurgicalProcedure.some((coding) => this.codeIsInSheet(coding, 'Treatment-Resection-Brain'))) {
-      // Is this metastasis_resection? It just seems to be specific to Brain.
-      surgicalValues.push('RESECTION');
-    }
-
+    // TODO - fill in with Surgical Procedures.
     return surgicalValues;
   }
 

--- a/src/mcode.ts
+++ b/src/mcode.ts
@@ -626,21 +626,24 @@ export class ExtractedMCODE {
     return null;
   }
 
-  // TODO - This will almost certainly be changed with new details from Trialjectory.
-  // Radiation Procedure
+  // --Procedures--
+  // lumpectomy
+  // mastectomy
+  // alnd
+  // reconstruction
+  // wbrt
+  // radiation
+  // metastasis_resection
+  // ablation
+  // rfa
+  // ebrt
+
+  // Radiation Procedures
   getRadiationProcedureValue(): string[] {
+    // Trialjectory does not differentiate between radiation/surgical procedures. How will that translate to the mCODE filters of radiation/surgical procedures?
+
     const radiationValues:string[] = [];
-    if (this.cancerRelatedRadiationProcedure.length == 0) {
-      return radiationValues;
-    }
-    for (const cancerRelatedRadiationProcedure of this.cancerRelatedRadiationProcedure) {
-      if (
-        cancerRelatedRadiationProcedure.coding &&
-        cancerRelatedRadiationProcedure.coding.some((coding) => this.codeIsInSheet(coding, 'Treatment-SRS-Brain'))
-      ) {
-        radiationValues.push('SRS');
-      }
-    }
+
     for (const cancerRelatedRadiationProcedure of this.cancerRelatedRadiationProcedure) {
       if (
         cancerRelatedRadiationProcedure.coding &&
@@ -657,36 +660,24 @@ export class ExtractedMCODE {
         radiationValues.push('WBRT');
       }
     }
+
+    // No logic for this?
     if (radiationValues.length == 0) {
       radiationValues.push('RADIATION_THERAPY');
     }
+
     return radiationValues;
   }
 
-  // TODO - This will almost certainly be changed with new details from Trialjectory.
-  // Surgical Procedure
+  // Surgical Procedures
   getSurgicalProcedureValue(): string[] {
     const surgicalValues:string[] = [];
-    if (this.cancerRelatedSurgicalProcedure.length == 0) {
-      return surgicalValues;
-    }
+
     if (this.cancerRelatedSurgicalProcedure.some((coding) => this.codeIsInSheet(coding, 'Treatment-Resection-Brain'))) {
+      // Is this metastasis_resection? It just seems to be specific to Brain.
       surgicalValues.push('RESECTION');
-    } else if (
-      this.cancerRelatedSurgicalProcedure.some((coding) => this.codeIsInSheet(coding, 'Treatment-Splenectomy'))
-    ) {
-      surgicalValues.push('SPLENECTOMY');
-    } else if (
-      this.cancerRelatedSurgicalProcedure.some(
-        (coding) => this.normalizeCodeSystem(coding.system) == 'SNOMED' && coding.code == '58390007'
-      )
-    ) {
-      surgicalValues.push('BONE_MARROW_TRANSPLANT');
-    } else if (
-      this.cancerRelatedSurgicalProcedure.some((coding) => this.codeIsInSheet(coding, 'Treatment-Organ_Transplant'))
-    ) {
-      surgicalValues.push('ORGAN_TRANSPLANT');
     }
+
     return surgicalValues;
   }
 

--- a/src/mcode.ts
+++ b/src/mcode.ts
@@ -368,6 +368,22 @@ export class ExtractedMCODE {
     return false;
   }
 
+    // Get ECOG Score
+    getECOGScore(): number {
+      if(this.ecogPerformaceStatus == -1) {
+        return null;
+      }
+      return this.ecogPerformaceStatus;
+    }
+  
+    // Get Karnofsky Score
+    getKarnofskyScore(): number {
+      if(this.karnofskyPerformanceStatus == -1) {
+        return null;
+      }
+      return this.karnofskyPerformanceStatus;
+    }
+
   // TODO - This will almost certainly be changed after more details from Trialjectory.
   // Primary Cancer Value
   getPrimaryCancerValue(): string {

--- a/src/mcode.ts
+++ b/src/mcode.ts
@@ -696,11 +696,8 @@ export class ExtractedMCODE {
   // Get Tumor Marker Values.
   getTumorMarkerValue(): string[] {
 
-    // TODO: Trialjectory Biomarkers not used: [atm, cdh1, chek2, nbn, nf1, palb2, pten, stk11, p53, esr1, pik3ca, pdl1, ntrk_fusion]
-    // Tialjectory Biomarkers used: [her2 (+ and -), pr (+ and -), er (+ and -), rb (+ only, should there be a -?), fgfr, brca1, brca2]
-
     if (this.tumorMarker.length == 0 && this.cancerGeneticVariant.length == 0) {
-      // Should return an empty array as opposed to 'NOT_SURE'? Or this is maybe not even necessary since it would just return an empty array at the end of the function anyway.
+      // Prevents unnecessary checks if the tumor marker values are empty.
       return [];
     }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -291,8 +291,7 @@ export class APIQuery {
       ecog: this.ecog,
       karnofsky: this.karnofsky,
       medications: this.medications,
-      radiationProcedures: this.radiationProcedures,
-      surgicalProcedures: this.surgicalProcedures,
+      procedures: this.radiationProcedures.concat(this.surgicalProcedures),
       metastasis: this.metastasis,
       age: this.age
       //conditions: this.conditions,
@@ -300,6 +299,7 @@ export class APIQuery {
   }
 
   toString(): string {
+    console.log(this.toQuery());
     // Note that if toQuery is no longer a string, this will no longer work
     return this.toQuery();
   }

--- a/src/query.ts
+++ b/src/query.ts
@@ -254,8 +254,8 @@ export class APIQuery {
     this.stage = extractedMCODE.getStageValues();
     this.cancerType = extractedMCODE.getPrimaryCancerValue();
     this.cancerSubType = extractedMCODE.getHistologyMorphologyValue();
-    this.ecog = extractedMCODE.ecogPerformaceStatus;
-    this.karnofsky = extractedMCODE.karnofskyPerformanceStatus;
+    this.ecog = extractedMCODE.getECOGScore();
+    this.karnofsky = extractedMCODE.getKarnofskyScore();
     this.medications = extractedMCODE.getMedicationStatementValues();
     this.radiationProcedures = extractedMCODE.getRadiationProcedureValue();
     this.surgicalProcedures = extractedMCODE.getSurgicalProcedureValue();


### PR DESCRIPTION
This Pull Request adds V2 of the research study mapping for Trialjectory. It includes:

- An updated query where radiation and surgical procedures are combined into one "procedures" array.
- Updates to use the existing procedures from Trialscope to be used in Trialjectory.
- Updates to Histology Morphology/Cancer Subtype strings to match Trialjectory.
- Updates to Ecog/Karnofsky.
- Tests for Ecog, Karnofsky, Histology/Subtype.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [x]	Does an update need to be made to the documentation with these changes?
- [x]	Does an update need to be made to the service wrappers as well?
- [x]	Does an update need to be made to the service library?
- [x] Was the new feature tested by unit tests?
- [x] Was the new feature tested by a manual, end-to-end test?
