### PR TITLE
Fix for formatting issue with trial descriptions

### DIFF
--- a/src/researchstudy-mapping.ts
+++ b/src/researchstudy-mapping.ts
@@ -70,7 +70,7 @@ export function convertToResearchStudy(trial: QueryTrial, id: number): ResearchS
   }
 
   if (trial.brief_summary) {
-    result.description = trial.brief_summary;
+    result.description = trial.brief_summary.split("    ").join('\n');
   }
 
   if (trial.main_objectives) {


### PR DESCRIPTION
Trial descriptions had parts separated by chunks of spaces, so the string was split by those chunks and then joined with newlines between each part to fix the formatting.

Pull requests into the clinical-trial-matching-service-template require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrappers as well?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
