### PR TITLE
Add Likelihood for TJ results

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -308,11 +308,21 @@ export function convertResponseToSearchSet(
   if (ctgService) {
     // If given a backup service, use it
     return ctgService.updateResearchStudies(studies).then(() => {
-      return new SearchSet(studies);
+      const ss = new SearchSet();
+      for (const study of studies) {
+        // If returned from TrialJectory, then the study has a match likelihood of 1
+        ss.addEntry(study, 1);
+      }
+      return ss;
     });
   } else {
     // Otherwise, resolve immediately
-    return Promise.resolve(new SearchSet(studies));
+    const ss = new SearchSet();
+    for (const study of studies) {
+      // If returned from TrialJectory, then the study has a match likelihood of 1
+      ss.addEntry(study, 1);
+    }
+    return Promise.resolve(ss);
   }
 }
 


### PR DESCRIPTION
Results that comeback from TJ are a match (as TJ doesn't return results that are not a match). Thus, results should be added to the search set with a match score of 1 to be utilized in the engine (for sorting reasons).

This PR adds the results to the SearchSet with a score of 1. 

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrappers as well?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
